### PR TITLE
latex: Add support for "|attr" to compute addplot attributes in SQL

### DIFF
--- a/src/latex.cpp
+++ b/src/latex.cpp
@@ -207,6 +207,7 @@ void SpLatex::multiplot(size_t ln, size_t indent, const std::string& cmdline)
     bool attrplus_mark = false;
     bool title_mark = false;
     bool ptitle_mark = false;
+    bool nolegend_mark = false;
     bool xerr = false, yerr = false;
 
     while (!groupfields.empty() && groupfields.back().find('|') != std::string::npos) {
@@ -222,6 +223,12 @@ void SpLatex::multiplot(size_t ln, size_t indent, const std::string& cmdline)
             field.resize(field.size() - 7);
             multiplot.resize(multiplot.size() - 7);
             ptitle_mark = true;
+        }
+        else if (!groupfields.empty() && is_suffix(field, "|nolegend")) {
+            // remove |nolegend from multiplot string
+            field.resize(field.size() - 9);
+            multiplot.resize(multiplot.size() - 9);
+            nolegend_mark = true;
         }
         else if (!groupfields.empty() && is_suffix(field, "|attr")) {
             // remove |attr from multiplot string
@@ -391,7 +398,7 @@ void SpLatex::multiplot(size_t ln, size_t indent, const std::string& cmdline)
     static const boost::regex
         re_addplot("[[:blank:]]*(\\\\addplot.*coordinates \\{)[^}]+(\\};.*)");
     static const boost::regex
-        re_legend("[[:blank:]]*(\\\\addlegendentry\\{).*(\\};.*)");
+        re_legend("[[:blank:]]*((?:%[[:blank:]]*)?\\\\addlegendentry\\{).*(\\};.*)");
 
     boost::smatch rm;
 
@@ -423,6 +430,9 @@ void SpLatex::multiplot(size_t ln, size_t indent, const std::string& cmdline)
             }
             else
             {
+                // If |nolegend is set, comment out legend entries
+                if (nolegend_mark)
+                    out << "% ";
                 // add missing \addlegendentry
                 out << "\\addlegendentry{" << legendlist[entry]
                     << "};" << std::endl;
@@ -458,6 +468,9 @@ void SpLatex::multiplot(size_t ln, size_t indent, const std::string& cmdline)
                 << " };" << std::endl;
         }
 
+        // If |nolegend is set, comment out legend entries
+        if (nolegend_mark)
+            out << "% ";
         out << "\\addlegendentry{" << legendlist[entry]
             << "};" << std::endl;
 

--- a/src/latex.cpp
+++ b/src/latex.cpp
@@ -208,24 +208,29 @@ void SpLatex::multiplot(size_t ln, size_t indent, const std::string& cmdline)
     bool ptitle_mark = false;
     bool xerr = false, yerr = false;
 
-    if (!groupfields.empty() && is_suffix(groupfields.back(), "|title")) {
-        // remove |title from multiplot string
-        groupfields.back().resize(groupfields.back().size() - 6);
-        multiplot.resize(multiplot.size() - 6);
-        title_mark = true;
-    }
-    else if (!groupfields.empty() && is_suffix(groupfields.back(), "|ptitle")) {
-        // remove |ptitle from multiplot string
-        groupfields.back().resize(groupfields.back().size() - 7);
-        multiplot.resize(multiplot.size() - 7);
-        ptitle_mark = true;
-    }
-
-    if (!groupfields.empty() && is_suffix(groupfields.back(), "|attr")) {
-        // remove |attr from multiplot string
-        groupfields.back().resize(groupfields.back().size() - 5);
-        multiplot.resize(multiplot.size() - 5);
-        attr_mark = true;
+    while (!groupfields.empty() && groupfields.back().find('|') != std::string::npos) {
+        std::string& field = groupfields.back();
+        if (!groupfields.empty() && is_suffix(field, "|title")) {
+            // remove |title from multiplot string
+            field.resize(field.size() - 6);
+            multiplot.resize(multiplot.size() - 6);
+            title_mark = true;
+        }
+        else if (!groupfields.empty() && is_suffix(field, "|ptitle")) {
+            // remove |ptitle from multiplot string
+            field.resize(field.size() - 7);
+            multiplot.resize(multiplot.size() - 7);
+            ptitle_mark = true;
+        }
+        else if (!groupfields.empty() && is_suffix(field, "|attr")) {
+            // remove |attr from multiplot string
+            field.resize(field.size() - 5);
+            multiplot.resize(multiplot.size() - 5);
+            attr_mark = true;
+        } else{
+            std::string modifier = field.substr(field.find('|'));
+            OUT_THROW("MULTIPLOT failed: unknown modifier '" + modifier + "'");
+        }
     }
 
     // execute query

--- a/src/latex.cpp
+++ b/src/latex.cpp
@@ -204,6 +204,7 @@ void SpLatex::multiplot(size_t ln, size_t indent, const std::string& cmdline)
     std::for_each(groupfields.begin(), groupfields.end(), trim_inplace_ws);
 
     bool attr_mark = false;
+    bool attrplus_mark = false;
     bool title_mark = false;
     bool ptitle_mark = false;
     bool xerr = false, yerr = false;
@@ -227,7 +228,15 @@ void SpLatex::multiplot(size_t ln, size_t indent, const std::string& cmdline)
             field.resize(field.size() - 5);
             multiplot.resize(multiplot.size() - 5);
             attr_mark = true;
-        } else{
+        }
+        else if (!groupfields.empty() && is_suffix(field, "|attrplus")) {
+            // remove |attrplus from multiplot string
+            field.resize(field.size() - 9);
+            multiplot.resize(multiplot.size() - 9);
+            attr_mark = true;
+            attrplus_mark = true;
+        }
+        else {
             std::string modifier = field.substr(field.find('|'));
             OUT_THROW("MULTIPLOT failed: unknown modifier '" + modifier + "'");
         }
@@ -395,7 +404,10 @@ void SpLatex::multiplot(size_t ln, size_t indent, const std::string& cmdline)
         {
             if (attr_mark) {
                 // can't copy styles when an attribute is being selected
-                out << "\\addplot[" << attrlist[entry] << "] coordinates { "
+                out << "\\addplot";
+                if (attrplus_mark)
+                    out << "+";
+                out << "[" << attrlist[entry] << "] coordinates {"
                     << coordlist[entry] << " " << rm[2] << std::endl;
             } else {
                 out << rm[1] << coordlist[entry] << " " << rm[2] << std::endl;
@@ -435,12 +447,16 @@ void SpLatex::multiplot(size_t ln, size_t indent, const std::string& cmdline)
     // append missing \addplot / \addlegendentry pairs
     while (entry < coordlist.size())
     {
-        if (attr_mark)
-            out << "\\addplot[" << attrlist[entry] << "] coordinates {"
+        if (attr_mark) {
+            out << "\\addplot";
+            if (attrplus_mark)
+                out << "+";
+            out << "[" << attrlist[entry] << "] coordinates {"
                 << coordlist[entry] << " };" << std::endl;
-        else
+        } else {
             out << "\\addplot coordinates {" << coordlist[entry]
                 << " };" << std::endl;
+        }
 
         out << "\\addlegendentry{" << legendlist[entry]
             << "};" << std::endl;


### PR DESCRIPTION
```sql
MULTIPLOT(algo|attr) SELECT size AS x, avg(time) AS y, "mark=" ||
iif(SUBSTR(algo, 1, 3) = "foo", "o", "*") AS attr FROM data GROUP BY MULTIPLOT
```
```latex
\addplot[mark=o] coordinates { (23, 1337), (42, 1234)  };
\addlegendentry{algo=foomatic9000}
\addplot[mark=*] coordinates { (23, 9001), (42, 9999)  };
\addlegendentry{algo=barosaurus}
```

What do you think? It can be combined with the other modifiers as `MULTIPLOT(algo|attr|title)`.