### PR TITLE
Use bool instead of my_bool for libmysql version 8 or higher

### DIFF
--- a/src/mysql.cpp
+++ b/src/mysql.cpp
@@ -38,7 +38,11 @@ struct MySqlBind : public MYSQL_BIND
 struct MySqlColumn
 {
     //! NULL value indicator
+    #if defined(LIBMYSQL_VERSION_ID) && LIBMYSQL_VERSION_ID >= 80000
+    bool is_null;
+    #else
     my_bool is_null;
+    #endif
 
     //! output string data, currently extra long strings are truncated.
     char strdata[128];


### PR DESCRIPTION
Starting from version 8 of libmysql, the type `my_bool` is no longer defined should be replaced by `int` or `bool` as per the [MySQL 8.0 Release Notes](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html#mysqld-8-0-1-compiling).

This PR adds a preprocessor-time test to see whether `LIBMYSQL_VERSION_ID` is defined as version 8 or higher and, if that is the case, replaces the single use of `my_bool` by `bool`.