### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,34 +14,34 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        # Run Tests on Ubuntu 18.04
-        - name: "Ubuntu 18.04 Debug SQLite"
-          os: ubuntu-18.04
+        # Run Tests on Ubuntu 22.04
+        - name: "Ubuntu 22.04 Debug SQLite"
+          os: ubuntu-22.04
           build_type: "Debug"
           test_database: "sqlite"
 
-        - name: "Ubuntu 18.04 Release SQLite"
-          os: ubuntu-18.04
+        - name: "Ubuntu 22.04 Release SQLite"
+          os: ubuntu-22.04
           build_type: "Release"
           test_database: "sqlite"
 
-        - name: "Ubuntu 18.04 Debug PostgreSQL"
-          os: ubuntu-18.04
+        - name: "Ubuntu 22.04 Debug PostgreSQL"
+          os: ubuntu-22.04
           build_type: "Debug"
           test_database: "postgresql"
 
-        - name: "Ubuntu 18.04 Release PostgreSQL"
-          os: ubuntu-18.04
+        - name: "Ubuntu 22.04 Release PostgreSQL"
+          os: ubuntu-22.04
           build_type: "Release"
           test_database: "postgresql"
 
-        - name: "Ubuntu 18.04 Debug MySQL"
-          os: ubuntu-18.04
+        - name: "Ubuntu 22.04 Debug MySQL"
+          os: ubuntu-22.04
           build_type: "Debug"
           test_database: "mysql"
 
-        - name: "Ubuntu 18.04 Release MySQL"
-          os: ubuntu-18.04
+        - name: "Ubuntu 22.04 Release MySQL"
+          os: ubuntu-22.04
           build_type: "Release"
           test_database: "mysql"
 
@@ -73,14 +73,16 @@ jobs:
           os: macos-latest
           build_type: "Debug"
           test_database: "sqlite"
+          cmake_flags: "-DWITH_POSTGRESQL=OFF"
 
         - name: "macOS Release SQLite"
           os: macos-latest
           build_type: "Release"
           test_database: "sqlite"
+          cmake_flags: "-DWITH_POSTGRESQL=OFF"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Boost
         if: ${{startsWith(matrix.config.os, 'ubuntu')}}
@@ -115,6 +117,7 @@ jobs:
           -DCMAKE_CXX_FLAGS="${{matrix.config.cxx_flags}}"
           -DTEST_DATABASE="${{matrix.config.test_database}}"
           -DBUILD_EXAMPLES=ON
+          ${{matrix.config.cmake_flags}}
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{matrix.config.build_type}}


### PR DESCRIPTION
This PR contains 3 changes that fix the CI build.

- Apparently, GitHub removed Postgres from the macOS runners, so CI on the `main` branch fails. This PR changes the GitHub action to build without Postgres when on macOS.
- The PR upgrades the checkout action to `checkout/v3` because of this warning message when running any action:

  > Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
- GitHub [no longer supports](https://github.com/actions/runner-images/issues/6002) Ubuntu 18.04 runners. This upgrades all 18.04 runners to 22.04, so we still have multiple different OS versions in the build matrix.